### PR TITLE
chore: promote jx3-golang-http to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-golang-http/jx3-golang-http-jx3-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-golang-http/jx3-golang-http-jx3-golang-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-golang-http-jx3-golang-http
   labels:
     draft: draft-app
-    chart: "jx3-golang-http-0.0.1"
+    chart: "jx3-golang-http-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-golang-http'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx3-golang-http-jx3-golang-http
       containers:
         - name: jx3-golang-http
-          image: "ghcr.io/dockerpac/jx3-golang-http:0.0.1"
+          image: "ghcr.io/dockerpac/jx3-golang-http:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-golang-http/jx3-golang-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-golang-http/jx3-golang-http-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-golang-http
   labels:
-    chart: "jx3-golang-http-0.0.1"
+    chart: "jx3-golang-http-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-golang-http'

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,11 +121,19 @@
 	    </tr>
     <tr>
 		      <td colspan='4'><h3>jx-production</h3></td>
-		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-golang-http </a></td>
 	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+		      <td colspan='4'><h3>jx-staging</h3></td>
+		    </tr>
+	    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-golang-http </a></td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -328,13 +328,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-11-14T21:26:26Z"
+    firstDeployed: "2021-11-14T22:24:13Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-11-14T21:26:26Z"
+    lastDeployed: "2021-11-14T22:24:13Z"
     name: jx3-golang-http
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/jx3-golang-http
-    version: 0.0.1
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/jx3-golang-http
-  version: 0.0.1
+  version: 0.0.2
   name: jx3-golang-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-golang-http to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
