### PR TITLE
chore: promote jx3-lensdevopscare-demo to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-ingress.yaml
+++ b/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jx3-lensdevopscare-demo/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'
+  name: jx3-lensdevopscare-demo
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jx3-lensdevopscare-demo
+                port:
+                  number: 80
+      host: jx3-lensdevopscare-demo-jx-production.lenscicd.pac.dockerps.io

--- a/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jx3-lensdevopscare-demo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
+  labels:
+    draft: draft-app
+    chart: "jx3-lensdevopscare-demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
+    spec:
+      serviceAccountName: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
+      containers:
+        - name: jx3-lensdevopscare-demo
+          image: "ghcr.io/dockerpac/jx3-lensdevopscare-demo:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-sa.yaml
+++ b/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jx3-lensdevopscare-demo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
+  annotations:
+    meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jx3-lensdevopscare-demo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-lensdevopscare-demo
+  labels:
+    chart: "jx3-lensdevopscare-demo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,6 +129,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-lensdevopscare-demo </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -324,6 +324,17 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-production/jx3-golang-http
     version: 0.0.1
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-11-14T23:06:35Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-11-14T23:06:35Z"
+    name: jx3-lensdevopscare-demo
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-production/jx3-lensdevopscare-demo
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/jx3-lensdevopscare-demo
   version: 0.0.1
   name: jx3-lensdevopscare-demo
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: jx3-golang-http
   values:
   - jx-values.yaml
+- chart: dev/jx3-lensdevopscare-demo
+  version: 0.0.1
+  name: jx3-lensdevopscare-demo
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-lensdevopscare-demo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
