### PR TITLE
chore: promote jx3-lensdevopscare-demo to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-jx3-lensdevopscare-demo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
   labels:
     draft: draft-app
-    chart: "jx3-lensdevopscare-demo-0.0.1"
+    chart: "jx3-lensdevopscare-demo-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx3-lensdevopscare-demo-jx3-lensdevopscare-demo
       containers:
         - name: jx3-lensdevopscare-demo
-          image: "ghcr.io/dockerpac/jx3-lensdevopscare-demo:0.0.1"
+          image: "ghcr.io/dockerpac/jx3-lensdevopscare-demo:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-lensdevopscare-demo/jx3-lensdevopscare-demo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-lensdevopscare-demo
   labels:
-    chart: "jx3-lensdevopscare-demo-0.0.1"
+    chart: "jx3-lensdevopscare-demo-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-lensdevopscare-demo'

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,7 +145,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-lensdevopscare-demo </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -350,13 +350,13 @@
     resourcePath: config-root/namespaces/jx-staging/jx3-golang-http
     version: 0.0.2
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-11-14T23:06:32Z"
+    firstDeployed: "2021-11-14T23:14:36Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-11-14T23:06:32Z"
+    lastDeployed: "2021-11-14T23:14:36Z"
     name: jx3-lensdevopscare-demo
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/jx3-lensdevopscare-demo
-    version: 0.0.1
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/jx3-lensdevopscare-demo
-  version: 0.0.1
+  version: 0.0.2
   name: jx3-lensdevopscare-demo
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-lensdevopscare-demo to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
