### PR TITLE
chore: promote jx3-demo1 to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-ingress.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jx3-demo1/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx3-demo1'
+  name: jx3-demo1
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jx3-demo1
+                port:
+                  number: 80
+      host: jx3-demo1-jx-production.lenscicd.pac.dockerps.io

--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: jx3-demo1/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demo1-jx3-demo1
+  labels:
+    draft: draft-app
+    chart: "jx3-demo1-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-demo1'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demo1-jx3-demo1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demo1-jx3-demo1
+    spec:
+      serviceAccountName: jx3-demo1-jx3-demo1
+      containers:
+        - name: jx3-demo1
+          image: "ghcr.io/dockerpac/jx3-demo1:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-sa.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jx3-demo1/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demo1-jx3-demo1
+  annotations:
+    meta.helm.sh/release-name: 'jx3-demo1'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jx3-demo1/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demo1
+  labels:
+    chart: "jx3-demo1-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx3-demo1'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demo1-jx3-demo1

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,15 @@
 	      <td></td>
 	      <td><a href='https://prometheus.io/'>source</a></td>
 	    </tr>
+    <tr>
+		      <td colspan='4'><h3>jx-production</h3></td>
+		    </tr>
+	    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-demo1 </a></td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -312,5 +312,17 @@
     version: 13.6.0
 - namespace: jx-production
   path: helmfiles/jx-production/helmfile.yaml
+  releases:
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-11-15T00:14:39Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2021-11-15T00:14:39Z"
+    name: jx3-demo1
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-production/jx3-demo1
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/jx3-demo1
   version: 0.0.1
   name: jx3-demo1
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,5 +7,9 @@ namespace: jx-production
 repositories:
 - name: dev
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+releases:
+- chart: dev/jx3-demo1
+  version: 0.0.1
+  name: jx3-demo1
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demo1 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
