### PR TITLE
chore: promote jx3-demo1 to version 0.0.4

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/jx3-demo1
-  version: 0.0.3
+  version: 0.0.4
   name: jx3-demo1
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-demo1 to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
