### PR TITLE
chore: promote jx3-demo1 to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-jx3-demo1-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demo1-jx3-demo1
   labels:
     draft: draft-app
-    chart: "jx3-demo1-0.0.4"
+    chart: "jx3-demo1-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-demo1'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: jx3-demo1-jx3-demo1
       containers:
         - name: jx3-demo1
-          image: "ghcr.io/dockerpac/jx3-demo1:0.0.4"
+          image: "ghcr.io/dockerpac/jx3-demo1:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo1/jx3-demo1-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demo1
   labels:
-    chart: "jx3-demo1-0.0.4"
+    chart: "jx3-demo1-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'jx3-demo1'

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,7 +124,13 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-demo1 </a></td>
-	      <td>0.0.4</td>
+	      <td>0.0.5</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx3-demo2 </a></td>
+	      <td>0.0.1</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -314,16 +314,16 @@
   path: helmfiles/jx-production/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.4
+    appVersion: 0.0.5
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-11-15T12:23:12Z"
+    firstDeployed: "2021-11-15T13:25:00Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-11-15T12:23:12Z"
+    lastDeployed: "2021-11-15T13:25:00Z"
     name: jx3-demo1
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-production/jx3-demo1
-    version: 0.0.4
+    version: 0.0.5
   - apiVersion: v1
     appVersion: 0.0.1
     description: A Helm chart for Kubernetes

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/jx3-demo1
-  version: 0.0.4
+  version: 0.0.5
   name: jx3-demo1
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-demo1 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
